### PR TITLE
Fix: Resolve frontend compilation error in Game.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Ignore node_modules for the frontend project
+ludo-frontend/node_modules/
+
+# Ignore build output
+ludo-frontend/build/
+
+# Ignore common OS files
+.DS_Store
+Thumbs.db
+
+# Ignore IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Log files
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/ludo-frontend/src/components/Game.js
+++ b/ludo-frontend/src/components/Game.js
@@ -33,7 +33,6 @@ const Game = ({ gameId: propGameId, myPlayerName, initialGameState, onReturnToLo
   const myPlayerColorRef = useRef(myPlayerColor); // Though myPlayerColor is stable from useState(assignedPlayerColor)
   const roundOverInfoRef = useRef(roundOverInfo);
   const overallWinnerInfoRef = useRef(overallWinnerInfo);
-  const assignedPlayerColorRef = useRef(assignedPlayerColor);
   const myPlayerNameRef = useRef(myPlayerName);
   // No messagesRef needed as addMessage is stable and handles messages state
 
@@ -42,7 +41,6 @@ const Game = ({ gameId: propGameId, myPlayerName, initialGameState, onReturnToLo
   useEffect(() => { overallWinnerInfoRef.current = overallWinnerInfo; }, [overallWinnerInfo]);
   // myPlayerColor, assignedPlayerColor, myPlayerName are props or derived from props and stable or handled by their own refs if necessary
   useEffect(() => { myPlayerColorRef.current = myPlayerColor; }, [myPlayerColor]);
-  // useEffect(() => { assignedPlayerColorRef.current = assignedPlayerColor; }, [assignedPlayerColor]); // assignedPlayerColor prop removed
   useEffect(() => { myPlayerNameRef.current = myPlayerName; }, [myPlayerName]);
 
   useEffect(() => {


### PR DESCRIPTION
I removed the unused `assignedPlayerColorRef` and its associated `useEffect` hook from `ludo-frontend/src/components/Game.js`. This variable was causing a "assignedPlayerColor is not defined" compilation error after previous changes.

The frontend now compiles successfully.