### PR TITLE
Refactor server dice roll logic and enhance diagnostics

### DIFF
--- a/ludo-online/game_logic/ludoGame.js
+++ b/ludo-online/game_logic/ludoGame.js
@@ -194,6 +194,8 @@ function getPlayerColor(game) {
         const playerIndex = game.current_player_index % game.activePlayerColors.length;
         return game.activePlayerColors[playerIndex];
     }
+    // If activePlayerColors is problematic, log debug info before erroring
+    console.log(`[ludoGame.js getPlayerColor DEBUG] Status: ${game.status}, ActiveColors: ${JSON.stringify(game.activePlayerColors)}, CurrentIndex: ${game.current_player_index}`);
     console.error("[ludoGame.js getPlayerColor] Error: activePlayerColors is undefined, empty, or current_player_index is problematic.");
     return null;
 }
@@ -271,6 +273,7 @@ function getMovablePawns(game, playerColor, diceValue) {
 }
 
 function switchPlayer(game) {
+    console.log(`[ludoGame.js switchPlayer DEBUG START] Status: ${game.status}, CurrentPlayerIndex (ending turn): ${game.current_player_index}, ActiveColors: ${JSON.stringify(game.activePlayerColors)}, NumPlayers: ${game.num_players}`);
     game.lastActivityTime = Date.now();
     game.lastLogMessage = null;
     game.lastLogMessageColor = null;
@@ -385,8 +388,18 @@ function switchPlayer(game) {
             }
         }
         // The specific game over check that was here previously is removed, as the new one is more comprehensive and placed earlier.
+
+        // Log state after determining next player and skipping eliminated ones
+        if (game.activePlayerColors && game.activePlayerColors.length > 0) {
+            const nextPlayerColor = game.activePlayerColors[game.current_player_index % game.activePlayerColors.length];
+            console.log(`[ludoGame.js switchPlayer DEBUG END] NextPlayerIndex: ${game.current_player_index}, NextPlayerColor: ${nextPlayerColor}, ActiveColors: ${JSON.stringify(game.activePlayerColors)}, NumPlayers: ${game.num_players}`);
+        } else {
+            console.log(`[ludoGame.js switchPlayer DEBUG END] NextPlayerIndex: ${game.current_player_index}, NO ACTIVE PLAYERS or activePlayerColors empty. ActiveColors: ${JSON.stringify(game.activePlayerColors)}, NumPlayers: ${game.num_players}`);
+        }
+
     } else { // c. Else (if activePlayerColors became empty and game over check didn't catch it)
         if (!game.overall_game_over) { // Only log if game wasn't already set to over by the timer logic
+            console.log(`[ludoGame.js switchPlayer DEBUG END] activePlayerColors is empty. Status: ${game.status}, CurrentPlayerIndex: ${game.current_player_index}, ActiveColors: ${JSON.stringify(game.activePlayerColors)}, NumPlayers: ${game.num_players}`);
             console.error("[ludoGame.js switchPlayer] Error: activePlayerColors is empty, but game was not declared over. Setting game over.");
             game.overall_game_over = true;
             game.status = 'gameOver';


### PR DESCRIPTION
This commit addresses potential instability in turn management by:

1. Refactoring the `socket.on('rollDice', ...)` handler in `server.js`:
   - The handler now delegates core dice roll processing (updating `game.dice_roll`, `awaitingMove`, `mustRollAgain`, `consecutive_sixes_count`, `threeTryAttempts`, and determining if the turn ends) to the authoritative `ludoGameLogic.processPlayerRoll()` function.
   - This removes complex duplicated logic from the server handler, centralizing it within `ludoGame.js` for better consistency and robustness.
   - The server now uses the outcome of `processPlayerRoll` and the updated game state to manage subsequent actions like emitting client events or calling `switchPlayer`.
   - This change is expected to resolve issues like "Current player: null" or "rolled a null" if they were caused by inconsistent state management in the previous server-side handler.
   - Note: The specific "earthquake mercy re-roll" server-side override in the `rollDice` handler was removed as part of this refactor. This feature, if essential, should be integrated into `ludoGame.js` (`processPlayerRoll`) for proper encapsulation of game logic.

2. Adding Diagnostic Logging in `ludoGame.js`:
   - Enhanced logging in `getPlayerColor()` to output game status, `activePlayerColors`, and `current_player_index` if it's about to return `null` due to problematic state.
   - Added logs at the beginning of `switchPlayer()` to show the state of the player whose turn is ending.
   - Added logs at the end of `switchPlayer()` to show the determined next player and relevant state variables.
   - These logs will aid in diagnosing any further issues related to turn progression.

The previous fixes for permanent player elimination in `switchPlayer` and `startNextRound` remain in place and are complemented by these changes.